### PR TITLE
Polish README labels and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ Personal cheat-sheet collection for developer tools, commands, and tips —
 primarily aimed at **.NET developers** working on **Windows** with **VS Code** or **Rider**.
 Topics include Git, Docker, Kubernetes, .NET, Blazor, VS Code, Rider, and more.
 
-## Setup
-
-After cloning, activate the pre-push validation hook:
-
-```bash
-git config core.hooksPath .githooks
-```
-
 ## IDE & Editors
 
 | Topic |
@@ -69,3 +61,11 @@ git config core.hooksPath .githooks
 | [Command Line Commands](Documents/TopTenCommandLineCommands.md) |
 | [PowerShell](Documents/PowerShell.md) |
 | [Chrome](Documents/Chrome.md) |
+
+## Setup
+
+After cloning, activate the pre-push validation hook:
+
+```bash
+git config core.hooksPath .githooks
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git config core.hooksPath .githooks
 
 | Topic |
 |-------|
-| [Tips & Tricks in VS Code](Documents/VsCode.md) |
+| [VS Code](Documents/VsCode.md) |
 | [Rider Keyboard Shortcuts](Documents/Rider.md) |
 | [Vim Editor](Documents/VimEditor.md) |
 | [Notepad++](Documents/NotepadPlusPlus.md) |
@@ -42,7 +42,7 @@ git config core.hooksPath .githooks
 | [EF Core](Documents/EntityFrameworkCore.md) |
 | [ABP CLI](Documents/ABPcli.md) |
 | [Advanced C#](Documents/AdvancedCSharp.md) |
-| [Tips & Tricks in Blazor](Documents/Blazor.md) |
+| [Blazor](Documents/Blazor.md) |
 
 ## Frontend & CSS
 
@@ -50,7 +50,7 @@ git config core.hooksPath .githooks
 |-------|
 | [Tailwind CSS](Documents/TailwindCss.md) |
 | [CSS](Documents/Css.md) |
-| [Tips & Tricks in NEXT.js](Documents/NextJs.md) |
+| [Next.js](Documents/NextJs.md) |
 
 ## Productivity & Learning
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git config core.hooksPath .githooks
 
 | Topic |
 |-------|
-| [Tips & Tricks in VsCode](Documents/VsCode.md) |
+| [Tips & Tricks in VS Code](Documents/VsCode.md) |
 | [Rider Keyboard Shortcuts](Documents/Rider.md) |
 | [Vim Editor](Documents/VimEditor.md) |
 | [Notepad++](Documents/NotepadPlusPlus.md) |
@@ -40,7 +40,7 @@ git config core.hooksPath .githooks
 |-------|
 | [.NET](Documents/DotNet.md) |
 | [EF Core](Documents/EntityFrameworkCore.md) |
-| [ABP cli](Documents/ABPcli.md) |
+| [ABP CLI](Documents/ABPcli.md) |
 | [Advanced C#](Documents/AdvancedCSharp.md) |
 | [Tips & Tricks in Blazor](Documents/Blazor.md) |
 
@@ -67,5 +67,5 @@ git config core.hooksPath .githooks
 |-------|
 | [All about Git](Documents/Git.md) |
 | [Command Line Commands](Documents/TopTenCommandLineCommands.md) |
-| [Powershell](Documents/PowerShell.md) |
+| [PowerShell](Documents/PowerShell.md) |
 | [Chrome](Documents/Chrome.md) |


### PR DESCRIPTION
## Summary

- Fixed capitalisation: `VsCode` → `VS Code`, `ABP cli` → `ABP CLI`, `Powershell` → `PowerShell`
- Removed redundant "Tips & Tricks in" prefix from VS Code, Blazor, and Next.js labels
- Moved Setup section to bottom so topic index is the first thing visitors see